### PR TITLE
Fix input trim

### DIFF
--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -161,8 +161,9 @@ class QRCode{
 	 * @throws \chillerlan\QRCode\Data\QRCodeDataException
 	 */
 	public function getMatrix(string $data):QRMatrix {
-        //NOTE: input sanitization should be done outside
-        //$data = trim($data);
+		//NOTE: input sanitization should be done outside
+		//$data = trim($data);
+		
 		if(empty($data)){
 			throw new QRCodeDataException('QRCode::getMatrix() No data given.');
 		}

--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -161,9 +161,8 @@ class QRCode{
 	 * @throws \chillerlan\QRCode\Data\QRCodeDataException
 	 */
 	public function getMatrix(string $data):QRMatrix {
-    //NOTE: data sanitation should be done outside
-    //$data = trim($data);
-
+        //NOTE: input sanitization should be done outside
+        //$data = trim($data);
 		if(empty($data)){
 			throw new QRCodeDataException('QRCode::getMatrix() No data given.');
 		}

--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -161,7 +161,8 @@ class QRCode{
 	 * @throws \chillerlan\QRCode\Data\QRCodeDataException
 	 */
 	public function getMatrix(string $data):QRMatrix {
-		$data = trim($data);
+    //NOTE: data sanitation should be done outside
+    //$data = trim($data);
 
 		if(empty($data)){
 			throw new QRCodeDataException('QRCode::getMatrix() No data given.');

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -94,12 +94,12 @@ class QRCodeTest extends QRTestAbstract{
 		$this->qrcode->getMatrix('');
 	}
 
-    public function testTrim() {
-        $m1 = $this->qrcode->getMatrix('hello');
-        $m2 = $this->qrcode->getMatrix('hello '); // added space
+	public function testTrim() {
+		$m1 = $this->qrcode->getMatrix('hello');
+		$m2 = $this->qrcode->getMatrix('hello '); // added space
 
-        $this->assertNotEquals($m1, $m2);
-    }
+		$this->assertNotEquals($m1, $m2);
+	}
 
 	public function testImageTransparencyBGDefault(){
 		$this->qrcode = $this->reflection->newInstanceArgs([new QROptions(['imageTransparencyBG' => 'foo'])]);

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -94,12 +94,12 @@ class QRCodeTest extends QRTestAbstract{
 		$this->qrcode->getMatrix('');
 	}
 
-  public function testTrim() {
-    $m1 = $this->qrcode->getMatrix('hello');
-    $m2 = $this->qrcode->getMatrix('hello '); // added space
+    public function testTrim() {
+        $m1 = $this->qrcode->getMatrix('hello');
+        $m2 = $this->qrcode->getMatrix('hello '); // added space
 
-    $this->assertNotEquals($m1, $m2);
-  }
+        $this->assertNotEquals($m1, $m2);
+    }
 
 	public function testImageTransparencyBGDefault(){
 		$this->qrcode = $this->reflection->newInstanceArgs([new QROptions(['imageTransparencyBG' => 'foo'])]);

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -94,6 +94,13 @@ class QRCodeTest extends QRTestAbstract{
 		$this->qrcode->getMatrix('');
 	}
 
+  public function testTrim() {
+    $m1 = $this->qrcode->getMatrix('hello');
+    $m2 = $this->qrcode->getMatrix('hello '); // added space
+
+    $this->assertNotEquals($m1, $m2);
+  }
+
 	public function testImageTransparencyBGDefault(){
 		$this->qrcode = $this->reflection->newInstanceArgs([new QROptions(['imageTransparencyBG' => 'foo'])]);
 


### PR DESCRIPTION
QRCode->getMatrix() trims the input which can produce unexpected results.

Here's an example that would produce the same output despite different inputs:
```
$qrcode = new QRCode($options);

$qrcode->render('hello');
$qrcode->render('hello '); // extra space
```

I've removed the trim() and added a test case. I think data trimming (if needed) should be done outside of the library.