### PR TITLE
Fixed version regression due to off-by-one error and added a test.

### DIFF
--- a/src/Data/QRMatrix.php
+++ b/src/Data/QRMatrix.php
@@ -82,7 +82,10 @@ class QRMatrix{
 	/**
 	 * @link http://www.thonky.com/qr-code-tutorial/format-version-tables
 	 */
-	const versionPattern = [ // no version pattern for QR Codes < 7
+	const versionPattern = [
+		// 1-based version index
+		null,
+		// no version pattern for QR Codes < 7
 		null   , null   , null   , null   , null   , null   , 0x07c94, 0x085bc, 0x09a99, 0x0a4d3,
 		0x0bbf6, 0x0c762, 0x0d847, 0x0e60d, 0x0f928, 0x10b78, 0x1145d, 0x12a17, 0x13532, 0x149a6,
 		0x15683, 0x168c9, 0x177ec, 0x18ec4, 0x191e1, 0x1afab, 0x1b08e, 0x1cc1a, 0x1d33f, 0x1ed75,

--- a/tests/Data/QRMatrixTest.php
+++ b/tests/Data/QRMatrixTest.php
@@ -23,6 +23,46 @@ class QRMatrixTest extends QRTestAbstract{
 	protected $version = 7;
 
 	/**
+	 * @link http://www.thonky.com/qr-code-tutorial/format-version-tables
+	 */
+	const VERSION_REF = [
+		7  => '000111110010010100',
+		8  => '001000010110111100',
+		9  => '001001101010011001',
+		10 => '001010010011010011',
+		11 => '001011101111110110',
+		12 => '001100011101100010',
+		13 => '001101100001000111',
+		14 => '001110011000001101',
+		15 => '001111100100101000',
+		16 => '010000101101111000',
+		17 => '010001010001011101',
+		18 => '010010101000010111',
+		19 => '010011010100110010',
+		20 => '010100100110100110',
+		21 => '010101011010000011',
+		22 => '010110100011001001',
+		23 => '010111011111101100',
+		24 => '011000111011000100',
+		25 => '011001000111100001',
+		26 => '011010111110101011',
+		27 => '011011000010001110',
+		28 => '011100110000011010',
+		29 => '011101001100111111',
+		30 => '011110110101110101',
+		31 => '011111001001010000',
+		32 => '100000100111010101',
+		33 => '100001011011110000',
+		34 => '100010100010111010',
+		35 => '100011011110011111',
+		36 => '100100101100001011',
+		37 => '100101010000101110',
+		38 => '100110101001100100',
+		39 => '100111010101000001',
+		40 => '101000110001101001'
+	];
+
+	/**
 	 * @var \chillerlan\QRCode\Data\QRMatrix
 	 */
 	protected $matrix;
@@ -59,6 +99,15 @@ class QRMatrixTest extends QRTestAbstract{
 
 	public function testVersion(){
 		$this->assertSame($this->version, $this->matrix->version());
+	}
+
+	public function testVersionPattern() {
+		foreach (self::VERSION_REF as $version => $mask) {
+			$hexRef = base_convert(self::VERSION_REF[$version],2 ,16);
+			$hexImpl = dechex(QRMatrix::versionPattern[$version]);
+
+			$this->assertEquals($hexRef, $hexImpl);
+		}
 	}
 
 	public function testECC(){


### PR DESCRIPTION
There was a regression moving from 2.0.4 to 2.0.5. The QRMatrix::versionPattern had an off-by-one error, due to reformatting.

I've fixed the bug and added a test following the spec found here: https://www.thonky.com/qr-code-tutorial/format-version-tables.