### PR TITLE
Fix PHP 8.1 deprecation

### DIFF
--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -215,7 +215,7 @@ class QRCode{
 
 		// allow forcing the data mode
 		// see https://github.com/chillerlan/php-qrcode/issues/39
-		$interface = $this::DATA_INTERFACES[strtolower($this->options->dataModeOverride)] ?? null;
+		$interface = $this::DATA_INTERFACES[strtolower((string) $this->options->dataModeOverride)] ?? null;
 
 		if($interface !== null){
 			return new $interface($this->options, $data);


### PR DESCRIPTION
Hi,

This fixes a minor deprecation in 4.3 branch for PHP 8.1.

Without this here is the risen deprecation:

> Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated 