### PR TITLE
The 'html' tag is missing in HTML output

### DIFF
--- a/src/Output/QRMarkupHTML.php
+++ b/src/Output/QRMarkupHTML.php
@@ -42,7 +42,7 @@ class QRMarkupHTML extends QRMarkup{
 		// wrap the snippet into a body when saving to file
 		if($saveToFile){
 			$html = sprintf(
-				'<!DOCTYPE html><head><meta charset="UTF-8"><title>QR Code</title></head><body>%s</body>',
+				'<!DOCTYPE html><html><head><meta charset="UTF-8"><title>QR Code</title></head><body>%s</body></html>',
 				$this->options->eol.$html
 			);
 		}


### PR DESCRIPTION
Found this minor bug.

Hope this helps

Reference : https://developer.mozilla.org/fr/docs/Web/HTML/Element/html 
