### PR TITLE
Fix link to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For the QRCode reader, either `ext-gd` or `ext-imagick` is required!
 
 ## Installation with [composer](https://getcomposer.org)
 
-See [the installation guide](https://php-qrcode.readthedocs.io/en/main/Usage-Installation.html) for more info!
+See [the installation guide](https://php-qrcode.readthedocs.io/en/main/Usage/Installation.html) for more info!
 
 
 ### Terminal


### PR DESCRIPTION
## Further comments

The current link https://php-qrcode.readthedocs.io/en/main/Usage-Installation.html leads to a 404 page.

The correct url is https://php-qrcode.readthedocs.io/en/main/Usage/Installation.html
