### PR TITLE
Reset scaled and length after toggling upscaled in QRGdImage

### DIFF
--- a/src/Output/QRGdImage.php
+++ b/src/Output/QRGdImage.php
@@ -163,6 +163,8 @@ abstract class QRGdImage extends QROutputAbstract{
 			// scale down to the expected size
 			$this->image    = imagescale($this->image, ($this->length / 10), ($this->length / 10));
 			$this->upscaled = false;
+			// Reset scaled and length values after rescaling image to prevent issues with subclasses that use the output from dump()
+			$this->setMatrixDimensions();
 		}
 
 		// set transparency after scaling, otherwise it would be undone


### PR DESCRIPTION
After subclassing to overlay a logo, I encountered massive images when using options->drawCircularModules
This was caused by scaling in underlying QrGdImage that doesn't reset underlying values.

## Proposed changes

Add in an a call to setMatrixDimensions() immediately after toggling upscaled back to false.
This should be a low cost way to reset the length and scale values to allow subclasses to use the output of dump()

<!-- You can erase any of the parts below that are not applicable to your Pull Request. -->

## Types of changes

<!-- Put an `x` in the boxes that apply -->

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have checked to ensure there aren't other open [Issues](../../../issues) or [Pull Requests](../../../pulls) for the same update/change