### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -216,7 +216,7 @@
 
 
 	<!--
-		Configurable built-in https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties
+		Configurable built-in https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties
 	-->
 
 	<rule ref="Generic.ControlStructures.InlineControlStructure">


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932